### PR TITLE
Infer the property a mutation writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ effects are errors; declared but unused effects are warnings. A function may
 use fewer effects than its declaration. No `yield`, wrapper function, or
 runtime handler is required.
 
+A `Mutate` region names the member path a write touches, so `state.calls = 1`
+infers `Mutate<typeof state.calls>`. Containment is prefix-based: declaring
+`Mutate<typeof state>` covers every member below it, while declaring a sibling
+property does not.
+
 ## Status
 
 This package is an alpha-stage research prototype, not a verifier for all of

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@ documentation are all updated.
 - [x] Publish one `uneffect` binary with subcommands, strict option parsing, `--help`/`--version`, and documented streams and exit codes, replacing the four ad-hoc CLI entry points.
 - [x] Check the toolchain before a run with `uneffect doctor`: Node, the peer TypeScript, `@types/node`, the Z3 WASM build, and the optional `z3`, `quint`, and `java` commands, each naming what it blocks and how to satisfy it.
 - [x] Drop the native Z3 installation from the toolchain: run ownership evidence on the `z3-solver` WASM build like contract verification already did, and keep it that way with a manifest test.
+- [x] Infer the member path a mutation writes, so `Mutate` names the property rather than only its container, and report a sibling-property declaration as an authority mismatch instead of a bare undeclared effect.
 
 The product-level completion gates are the skipped executable scenarios in
 `test/acceptance-roadmap.test.ts`. Before adding another narrow feature, select

--- a/docs/effect-system.md
+++ b/docs/effect-system.md
@@ -57,6 +57,19 @@ Mutate<typeof state> permits Mutate<typeof state.user>
 Mutate<typeof left> does not permit Mutate<typeof right>
 ```
 
+Inference names the region a write actually touches, down to the property:
+`state.calls = 1` infers `Mutate<typeof state.calls>`, and `state.items.push(x)`
+infers `Mutate<typeof state.items>` — the receiver the builtin mutates. A
+declaration of any prefix still permits it, so `Mutate<typeof state>` covers
+both; a declaration of a sibling property does not, and the diagnostic says so
+rather than only reporting an undeclared effect.
+
+An element access is only as precise as its key. A literal key is a property, so
+`table["ready"] = v` infers `Mutate<typeof table.ready>`. A computed key names no
+member the checker can compare, so `values[index] = v` widens to
+`Mutate<typeof values>` — which is why the quicksort dogfood still proves exactly
+`Mutate<typeof values>`.
+
 Parameter regions are substituted at call sites. **Implemented across TypeChecker-resolved program edges, including aliases, methods, arrows, overloads, and callbacks.** The current escape filter proves freshly declared locals non-observable; deeper heap escape analysis remains conservative.
 
 `Throw<E>` is covariant over known `Error` subtypes. `Throw<Error>` admits a concrete error such as `Throw<RangeError>`, but does not admit `Throw<unknown>`, which represents JavaScript throwing a value not proven assignable to the global `Error` interface. The frontend performs that subtype check with the TypeChecker, including constrained type parameters. A synchronous `catch` discharges all `Throw<E>` effects originating in its `try` block. Throws from the `catch` or `finally` block still propagate.

--- a/docs/gradual-annotations.md
+++ b/docs/gradual-annotations.md
@@ -69,7 +69,15 @@ effect_term  = qualified_name
              | "Mutate", "<", "typeof", region, ">"
              | "Throw", "<", error_type, ">"
              | scoped_effect ;
+region       = identifier, { ".", identifier | "[", string_literal, "]" } ;
 ```
+
+A region is a member path, so it can name a single property: `Mutate<typeof
+state.calls>` is the authority to write that property, and a declaration of any
+prefix (`Mutate<typeof state>`) permits everything below it. Inference produces
+the path the code actually writes; see the
+[effect system](./effect-system.md) for containment and for how computed keys
+widen to their container.
 
 A return refinement describes a value more precisely for Uneffect analysis without changing runtime behavior:
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -8,7 +8,7 @@ anything.
 
 | directory | what it demonstrates |
 | --- | --- |
-| `effects/` | declared vs. inferred effects, transitive propagation through calls, scoped authorities, unused and misspelled declarations |
+| `effects/` | declared vs. inferred effects, transitive propagation through calls, scoped authorities, property-level mutation regions, unused and misspelled declarations |
 | `contracts/` | Hoare triples Z3 proves, postcondition and loop-invariant counterexamples, and the limits of the verified subset |
 | `async/` | floating Promises and `using` disposal errors |
 

--- a/fixtures/effects/mutate-property.diag
+++ b/fixtures/effects/mutate-property.diag
@@ -1,0 +1,16 @@
+$ uneffect check --evidence fixtures/effects/mutate-property.ts
+# A write names the property it touches, so declaring a sibling property does not cover it.
+
+error effect/missing fixtures/effects/mutate-property.ts:5 in record
+  message: record requires /* uneffect: effect Mutate<typeof state.total> */
+  5 | export function record(weight: number) {
+    | ^
+  declared: Mutate<typeof state.calls>
+  because: record performs state.total += weight at line 7
+  out of authority: the declared Mutate<typeof state.calls> names a different region of state; a region only permits itself and the members below it
+  hint: declare the effect in the function's /* uneffect: effect ... */ comment, or move the operation into a callee that already declares it
+
+1 error(s), 0 warning(s)
+
+evidence:
+  effects record: Mutate<typeof state.calls> | Mutate<typeof state.total> (unknown)

--- a/fixtures/effects/mutate-property.ts
+++ b/fixtures/effects/mutate-property.ts
@@ -1,0 +1,8 @@
+// A write names the property it touches, so declaring a sibling property does not cover it.
+const state = { calls: 0, total: 0 };
+
+/* uneffect: effect Mutate<typeof state.calls> */
+export function record(weight: number) {
+  state.calls += 1;
+  state.total += weight;
+}

--- a/fixtures/effects/mutation-effect.diag
+++ b/fixtures/effects/mutation-effect.diag
@@ -1,8 +1,8 @@
 $ uneffect check --evidence fixtures/effects/mutation-effect.ts
-# Writing through a binding that outlives the call is a Mutate effect over that region.
+# Writing through a binding that outlives the call is a Mutate effect over the written region.
 
 error effect/missing fixtures/effects/mutation-effect.ts:4 in record
-  message: record requires /* uneffect: effect Mutate<typeof state> */
+  message: record requires /* uneffect: effect Mutate<typeof state.calls> */
   4 | export function record() {
     | ^
   declared: (no /* uneffect: effect ... */ comment)
@@ -12,4 +12,4 @@ error effect/missing fixtures/effects/mutation-effect.ts:4 in record
 1 error(s), 0 warning(s)
 
 evidence:
-  effects record: Mutate<typeof state> (inferred)
+  effects record: Mutate<typeof state.calls> (inferred)

--- a/fixtures/effects/mutation-effect.ts
+++ b/fixtures/effects/mutation-effect.ts
@@ -1,4 +1,4 @@
-// Writing through a binding that outlives the call is a Mutate effect over that region.
+// Writing through a binding that outlives the call is a Mutate effect over the written region.
 const state = { calls: 0 };
 
 export function record() {

--- a/fixtures/quality.md
+++ b/fixtures/quality.md
@@ -13,7 +13,7 @@ regress; the remaining ones move the score and point at the next message to impr
 | action | yes | does a hint say what to change next? |
 | plain-language | yes | is the message free of raw solver verdicts and SMT jargon? |
 
-Score: **1.000** (120/120 criteria over 20 diagnostics, threshold 1.000)
+Score: **1.000** (126/126 criteria over 21 diagnostics, threshold 1.000)
 
 | fixture | diagnostic | line | missing |
 | --- | --- | --- | --- |
@@ -26,6 +26,7 @@ Score: **1.000** (120/120 criteria over 20 diagnostics, threshold 1.000)
 | fixtures/contracts/unsupported-call.ts | contract/unsupported | 11 | — |
 | fixtures/contracts/unsupported-parameter-type.ts | contract/unsupported | 3 | — |
 | fixtures/effects/missing-console.ts | effect/missing | 2 | — |
+| fixtures/effects/mutate-property.ts | effect/missing | 5 | — |
 | fixtures/effects/mutation-effect.ts | effect/missing | 4 | — |
 | fixtures/effects/scoped-fetch.ts | effect/missing | 8 | — |
 | fixtures/effects/scoped-fetch.ts | effect/missing | 8 | — |

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -55,7 +55,44 @@ function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
 function sameConstructor(left: Effect, right: Effect): boolean {
   if (left.kind !== right.kind || formatEffect(left) === formatEffect(right)) return false;
   if (left.kind === "capability" && right.kind === "capability") return left.name === right.name;
+  if (left.kind === "mutate" && right.kind === "mutate") return regionRoot(left.region) === regionRoot(right.region);
   return left.kind === "throw";
+}
+
+/** The declaration a diagnostic is judged against, shown so a reader need not open the source. */
+function declaredNote(declared: readonly Effect[]): DiagnosticNote {
+  return { label: "declared", detail: declared.length > 0 ? declared.map(formatEffect).join(" | ") : "(no /* uneffect: effect ... */ comment)" };
+}
+
+function inferredNote(actual: readonly Effect[]): DiagnosticNote {
+  return { label: "inferred", detail: actual.length > 0 ? actual.map(formatEffect).join(" | ") : "no effect" };
+}
+
+/** Notes shared by both analyzers; the program-wide path adds the origin of the effect. */
+function missingEffectNotes(declared: readonly Effect[], effect: Effect, origin?: string): DiagnosticNote[] {
+  const related = declared.filter((item) => sameConstructor(item, effect));
+  return [
+    declaredNote(declared),
+    ...(origin ? [{ label: "because", detail: origin }] : []),
+    ...(related.length > 0 ? [{ label: "out of authority", detail: authorityMismatch(related, effect) }] : []),
+  ];
+}
+
+function unusedEffectNotes(name: string, declared: readonly Effect[], actual: readonly Effect[], effect: Effect): DiagnosticNote[] {
+  return [declaredNote(declared), inferredNote(actual), { label: "because", detail: `nothing in ${name} or its callees produces ${formatEffect(effect)}` }];
+}
+
+function unknownEffectNotes(declared: readonly Effect[], effect: Effect): DiagnosticNote[] {
+  return [declaredNote(declared), { label: "because", detail: `${formatEffect(effect)} is not one of the effect constructors this checker understands, so it constrains nothing` }];
+}
+
+/** Why a declaration that looks related still does not permit the required effect. */
+function authorityMismatch(declared: readonly Effect[], required: Effect): string {
+  const names = declared.map(formatEffect).join(" | ");
+  if (required.kind === "mutate") {
+    return `the declared ${names} names a different region of ${regionRoot(required.region)}; a region only permits itself and the members below it`;
+  }
+  return `the declared ${names} shares this effect constructor, but its arguments do not cover ${formatEffect(required)}`;
 }
 
 function snippet(node: ts.Node, source: ts.SourceFile): string {
@@ -74,12 +111,35 @@ function declaration(source: ts.SourceFile, node: ts.Node): Effect[] {
   return extractAnnotations(text, "effect").flatMap((value) => splitTopLevel(value, "|")).map(parseEffectExpression);
 }
 
+/** Property names that can be written as a member path; anything else stays bracketed. */
+const plainMember = /^[A-Za-z_$][\w$]*$/u;
+
+/**
+ * The region a write names: the member path of the location itself, so `state.calls = 1` is
+ * `Mutate<typeof state.calls>` rather than the whole of `state`. A declaration of the container
+ * still permits it, because region containment is prefix-based.
+ *
+ * An element access is only as precise as its key: a literal key is a property, while a computed
+ * one names no member the checker can compare, so the region conservatively widens to the container.
+ */
 function mutationRegion(expression: ts.Expression): string {
-  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) return expression.expression.getText();
+  if (ts.isParenthesizedExpression(expression) || ts.isNonNullExpression(expression)
+    || ts.isAsExpression(expression) || ts.isTypeAssertionExpression(expression)) return mutationRegion(expression.expression);
+  if (ts.isPropertyAccessExpression(expression)) return `${mutationRegion(expression.expression)}.${expression.name.text}`;
+  if (ts.isElementAccessExpression(expression)) {
+    const container = mutationRegion(expression.expression), key = expression.argumentExpression;
+    if (ts.isStringLiteralLike(key)) return plainMember.test(key.text) ? `${container}.${key.text}` : `${container}["${key.text}"]`;
+    return container;
+  }
   return expression.getText();
 }
 function mutateEffect(expression: ts.Expression): Effect {
   return { kind: "mutate", region: mutationRegion(expression) };
+}
+
+/** The binding a region is rooted at, used to tell a different property from a different object. */
+function regionRoot(region: string): string {
+  return /^[A-Za-z_$][\w$]*/u.exec(region)?.[0] ?? region;
 }
 
 function localBindings(scope: ts.FunctionLikeDeclaration): Set<string> {
@@ -532,14 +592,17 @@ function analyzeSource(source: ts.SourceFile, options: EffectAnalysisOptions, ad
       fileName, functionName: info.name, effect: formatEffect(effect), kind: "unknown",
       severity: options.mode === "strict" ? "error" : "warning", line,
       message: `${info.name} declares unknown effect ${formatEffect(effect)}`,
+      notes: unknownEffectNotes(info.declared, effect),
     });
     for (const effect of actual) if (!permits(info.declared, effect) && (info.declared.length > 0 || options.requireAnnotations !== false)) diagnostics.push({
       fileName, functionName: info.name, effect: formatEffect(effect), kind: "missing", severity: "error", line,
       message: `${info.name} requires /* uneffect: effect ${formatEffect(effect)} */`,
+      notes: missingEffectNotes(info.declared, effect),
     });
     for (const effect of info.declared) if (![...actual].some((item) => permits([effect], item))) diagnostics.push({
       fileName, functionName: info.name, effect: formatEffect(effect), kind: "unused", severity: "warning", line,
       message: `${info.name} declares unused effect ${formatEffect(effect)}`,
+      notes: unusedEffectNotes(info.name, info.declared, actual, effect),
     });
   }
   const summaries = [...functions.values()].map((info): EffectSummary => {
@@ -723,23 +786,16 @@ export function analyzeProgramEffects(program: ts.Program, options: EffectAnalys
   for (const graphNode of graph.nodes) {
     const actual = inferred.get(graphNode.id)!, allowed = declared.get(graphNode.id)!, source = nodes.get(graphNode.id)!.getSourceFile();
     const line = source.getLineAndCharacterOfPosition(graphNode.span.start).line + 1;
-    const declaredNote: DiagnosticNote = { label: "declared", detail: allowed.length > 0 ? allowed.map(formatEffect).join(" | ") : "(no /* uneffect: effect ... */ comment)" };
-    for (const effect of allowed) if (!isKnownEffect(effect)) diagnostics.push({ fileName: source.fileName, functionName: graphNode.name, effect: formatEffect(effect), kind: "unknown", severity: options.mode === "strict" ? "error" : "warning", line, message: `${graphNode.name} declares unknown effect ${formatEffect(effect)}`, notes: [declaredNote, { label: "because", detail: `${formatEffect(effect)} is not one of the effect constructors this checker understands, so it constrains nothing` }] });
+    for (const effect of allowed) if (!isKnownEffect(effect)) diagnostics.push({ fileName: source.fileName, functionName: graphNode.name, effect: formatEffect(effect), kind: "unknown", severity: options.mode === "strict" ? "error" : "warning", line, message: `${graphNode.name} declares unknown effect ${formatEffect(effect)}`, notes: unknownEffectNotes(allowed, effect) });
     for (const effect of actual) if (!permits(allowed, effect) && (allowed.length > 0 || options.requireAnnotations !== false)) {
       const key = formatEffect(effect);
-      const because = origin(graphNode.id, key, source.fileName);
-      const narrower = allowed.filter((item) => sameConstructor(item, effect)).map(formatEffect);
       diagnostics.push({
         fileName: source.fileName, functionName: graphNode.name, effect: key, kind: "missing", severity: "error", line,
         message: `${graphNode.name} requires /* uneffect: effect ${key} */`,
-        notes: [
-          declaredNote,
-          ...(because ? [{ label: "because", detail: because }] : []),
-          ...(narrower.length > 0 ? [{ label: "out of authority", detail: `the declared ${narrower.join(" | ")} shares this effect constructor, but its arguments do not cover ${key}` }] : []),
-        ],
+        notes: missingEffectNotes(allowed, effect, origin(graphNode.id, key, source.fileName)),
       });
     }
-    for (const effect of allowed) if (!actual.some((item) => permits([effect], item))) diagnostics.push({ fileName: source.fileName, functionName: graphNode.name, effect: formatEffect(effect), kind: "unused", severity: "warning", line, message: `${graphNode.name} declares unused effect ${formatEffect(effect)}`, notes: [declaredNote, { label: "inferred", detail: actual.length > 0 ? actual.map(formatEffect).join(" | ") : "no effect" }, { label: "because", detail: `nothing in ${graphNode.name} or its callees produces ${formatEffect(effect)}` }] });
+    for (const effect of allowed) if (!actual.some((item) => permits([effect], item))) diagnostics.push({ fileName: source.fileName, functionName: graphNode.name, effect: formatEffect(effect), kind: "unused", severity: "warning", line, message: `${graphNode.name} declares unused effect ${formatEffect(effect)}`, notes: unusedEffectNotes(graphNode.name, allowed, actual, effect) });
     const own = diagnostics.filter((diagnostic) => diagnostic.fileName === source.fileName && diagnostic.functionName === graphNode.name);
     const evidence: EvidenceStatus = unknownTiming.has(graphNode.id) || unknownGeneratorEvidence.has(graphNode.id) || unknownGeneratorParameterEvidence.has(graphNode.id) ? "unknown" : allowed.length === 0 ? "inferred" : own.some((diagnostic) => diagnostic.severity === "error") ? "unknown" : "verified";
     summaries.push({ functionName: graphNode.name, effects: actual, evidence, id: graphNode.id, fileName: graphNode.fileName, span: graphNode.span });

--- a/test/effects.test.ts
+++ b/test/effects.test.ts
@@ -360,8 +360,56 @@ describe("effect checker", () => {
       function bad(left: { n: number }, right: { n: number }) { right.n = left.n }
     `;
     expect(analyzeEffects("mutate.ts", source)).toContainEqual(
-      expect.objectContaining({ functionName: "bad", effect: "Mutate<typeof right>", kind: "missing" }),
+      expect.objectContaining({ functionName: "bad", effect: "Mutate<typeof right.n>", kind: "missing" }),
     );
+  });
+
+  it("names the written property, not only the object that holds it", () => {
+    const source = `
+      /* uneffect: effect Mutate<typeof state.calls> */
+      function bump(state: { calls: number; total: number }) { state.total += 1 }
+    `;
+    const [missing] = analyzeEffects("mutate.ts", source);
+    expect(missing).toMatchObject({ functionName: "bump", effect: "Mutate<typeof state.total>", kind: "missing" });
+    expect(missing?.notes).toContainEqual(expect.objectContaining({
+      label: "out of authority",
+      detail: expect.stringContaining("names a different region of state"),
+    }));
+  });
+
+  it("accepts a declaration of exactly the written property", () => {
+    expect(analyzeEffects("mutate.ts", `
+      /* uneffect: effect Mutate<typeof state.calls> */
+      function bump(state: { calls: number; total: number }) { state.calls += 1 }
+    `)).toEqual([]);
+  });
+
+  it("keeps a mutating builtin at the receiver it is called on", () => {
+    expect(analyzeEffects("mutate.ts", `
+      /* uneffect: effect Mutate<typeof state.items> */
+      function add(state: { items: number[] }, value: number) { state.items.push(value) }
+    `)).toEqual([]);
+  });
+
+  it("widens a computed element write to its container and keeps a literal key a property", () => {
+    const dynamic = analyzeEffects("mutate.ts", `
+      function write(values: number[], index: number, value: number) { values[index] = value }
+    `);
+    expect(dynamic).toContainEqual(expect.objectContaining({ effect: "Mutate<typeof values>", kind: "missing" }));
+
+    const literal = analyzeEffects("mutate.ts", `
+      function write(table: Record<string, number>, value: number) { table["ready"] = value }
+    `);
+    expect(literal).toContainEqual(expect.objectContaining({ effect: "Mutate<typeof table.ready>", kind: "missing" }));
+  });
+
+  it("substitutes a member-path region through a call", () => {
+    expect(analyzeEffects("mutate.ts", `
+      /* uneffect: effect Mutate<typeof target.count> */
+      function increment(target: { count: number }) { target.count++ }
+      /* uneffect: effect Mutate<typeof state.inner.count> */
+      function update(state: { inner: { count: number } }) { increment(state.inner) }
+    `)).toEqual([]);
   });
 
   it("tracks the concrete Error constructed by a throw statement", () => {


### PR DESCRIPTION
`Mutate` の region を、書き込んだメンバーパスまで具体化しました。

## 何が問題だったか

`state.calls = 1` は `Mutate<typeof state>` と推論されていました（`mutationRegion` が最後のプロパティを捨てていた）。結果として:

- 診断が「どのプロパティを書いたか」を言えない
- あるプロパティを宣言すると、同じオブジェクトの**他のすべてのプロパティへの書き込みも通ってしまう**

包含規則（`atomCovers` の region 前方一致）と呼び出し越しの region 置換は最初からメンバーパス対応だったので、推論側だけが情報を落としていました。

## 変更後

| 書き込み | 推論される region |
| --- | --- |
| `state.calls = 1` / `state.calls++` | `Mutate<typeof state.calls>` |
| `state.items.push(x)` | `Mutate<typeof state.items>`（builtin が変更するレシーバ。従来は `state`） |
| `table["ready"] = v` | `Mutate<typeof table.ready>`（リテラルキーはプロパティ） |
| `values[index] = v` | `Mutate<typeof values>`（計算キーは比較できるメンバーを指さないのでコンテナに広げる） |

計算キーを広げる規則のおかげで、quicksort の dogfood は従来どおり `Mutate<typeof values>` ちょうどを証明します。

前方一致の包含は変わらないので、`Mutate<typeof state>` と宣言している既存の注釈はすべてそのまま通ります。通らなくなるのは「兄弟プロパティを宣言していたケース」で、それは今回の目的そのものです。その場合の診断:

```
error effect/missing fixtures/effects/mutate-property.ts:5 in record
  message: record requires /* uneffect: effect Mutate<typeof state.total> */
  declared: Mutate<typeof state.calls>
  because: record performs state.total += weight at line 7
  out of authority: the declared Mutate<typeof state.calls> names a different region of state; a region only permits itself and the members below it
  hint: declare the effect in the function's /* uneffect: effect ... */ comment, or move the operation into a callee that already declares it
```

「未宣言の effect がある」ではなく「同じ root の別 region を宣言している」と言い分けます（`sameConstructor` を mutate に拡張）。

## ついでに直したもの

単一ファイル解析（`analyzeEffects`）の effect 診断に notes が付いておらず、CLI が使うプログラム全体解析より弱いメッセージを返していました。両者を共通の note ビルダー（`declaredNote` / `missingEffectNotes` / `unusedEffectNotes` / `unknownEffectNotes`）から組み立てるようにして、差をなくしています。

## 検査

- fast tier 271 tests グリーン（`effects` に 6 ケース追加: プロパティ単位の一致・不一致、builtin レシーバ、計算キーの広がり、リテラルキーの正規化、メンバーパスの呼び出し越し置換）
- `fixtures/` に `mutate-property` を追加、`mutation-effect.diag` を再生成、diagnostic quality 1.000 を維持
- dogfood / acceptance-roadmap / evidence-optimizer / fixtures / project-optimizer を実行。`dogfood` の telemetry-routing-accounting が 30s timeout に当たりますが、**私の変更を stash した状態でも 28.34s、変更ありで 28.54s** と差がなく（このコンテナが重いだけ）、CI では通っています。

## 補足

最後の「Replecae wdatoka,」が読み取れませんでした。`Replace` に関する別の提案でしたら、内容を教えてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDhfUekVTSeWtp1bv1skGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDhfUekVTSeWtp1bv1skGJ)_